### PR TITLE
Fix keypath crash

### DIFF
--- a/flare_dart/lib/animation/keyframe.dart
+++ b/flare_dart/lib/animation/keyframe.dart
@@ -1141,6 +1141,8 @@ class KeyFrameStrokeStart extends KeyFrameNumeric {
     if (component == null) return;
 
     ActorStroke star = component as ActorStroke;
+    if(star.trimStart == null) return;
+
     star.trimStart = star.trimStart * (1.0 - mix) + value * mix;
   }
 }

--- a/flare_flutter/pubspec.yaml
+++ b/flare_flutter/pubspec.yaml
@@ -8,9 +8,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-#  flare_dart: ^1.2.0
   flare_dart:
-    path: ../flare_dart
+    git:
+      url: https://github.com/iuraiura879/Flare-Flutter.git
+      path: flare_dart
+      ref: fix-keypath-crash
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/flare_flutter/pubspec.yaml
+++ b/flare_flutter/pubspec.yaml
@@ -8,9 +8,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flare_dart: ^1.2.0
-#  flare_dart:
-#    path: ../flare_dart
+#  flare_dart: ^1.2.0
+  flare_dart:
+    path: ../flare_dart
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
In some situations, flare puts out key-frames that are somehow null. Added a guard against that. Attaching an animation that didn't work before and works after.
[question.zip](https://github.com/2d-inc/Flare-Flutter/files/2800570/question.zip)
