### PR TITLE
Using the assetBundle from the context instead of hardcoded PlatformAssetBundle

### DIFF
--- a/flare_flutter/lib/flare.dart
+++ b/flare_flutter/lib/flare.dart
@@ -2,7 +2,7 @@ library flare_flutter;
 
 import 'dart:ui' as ui;
 import 'dart:math';
-import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter/services.dart';
 import 'dart:async';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
@@ -556,9 +556,9 @@ class FlutterActor extends Actor {
     return FlutterRadialStroke();
   }
 
-  Future<bool> loadFromBundle(String filename) async {
+  Future<bool> loadFromBundle(AssetBundle assetBundle, String filename) async {
     Completer<bool> completer = Completer<bool>();
-    rootBundle.load(filename).then((ByteData data) {
+    assetBundle.load(filename).then((ByteData data) {
       super.load(data);
       completer.complete(true);
     });

--- a/flare_flutter/lib/flare_actor.dart
+++ b/flare_flutter/lib/flare_actor.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flare_dart/actor_drawable.dart';
 import 'package:flare_dart/math/mat2d.dart';
@@ -38,6 +39,7 @@ class FlareActor extends LeafRenderObjectWidget {
   @override
   RenderObject createRenderObject(BuildContext context) {
     return FlareActorRenderObject()
+      ..assetBundle = DefaultAssetBundle.of(context)
       ..filename = filename
       ..fit = fit
       ..alignment = alignment
@@ -54,6 +56,7 @@ class FlareActor extends LeafRenderObjectWidget {
   void updateRenderObject(
       BuildContext context, covariant FlareActorRenderObject renderObject) {
     renderObject
+      ..assetBundle = DefaultAssetBundle.of(context)
       ..filename = filename
       ..fit = fit
       ..alignment = alignment
@@ -82,6 +85,7 @@ class FlareAnimationLayer {
 }
 
 class FlareActorRenderObject extends RenderBox {
+  AssetBundle assetBundle;
   String _filename;
   BoxFit _fit;
   Alignment _alignment;
@@ -218,7 +222,7 @@ class FlareActorRenderObject extends RenderBox {
       }
 
       FlutterActor actor = FlutterActor();
-      actor.loadFromBundle(_filename).then((bool success) {
+      actor.loadFromBundle(assetBundle, _filename).then((bool success) {
         if (success) {
           _actor = actor;
           _artboard = _actor?.artboard;


### PR DESCRIPTION
This is also needed when doing widget testing