### PR TITLE
fix flare_dart path

### DIFF
--- a/flare_flutter/pubspec.yaml
+++ b/flare_flutter/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   flare_dart:
-    path: ../flare_dart
+    path: flare_dart
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
the previous path was relative and would result in an error if attempted to load the plugin via git