### PR TITLE
Fixing pubspec error.

### DIFF
--- a/flare_flutter/pubspec.yaml
+++ b/flare_flutter/pubspec.yaml
@@ -8,4 +8,7 @@ environment:
 dependencies:
   flutter_web: any
   flare_dart:
-    path: ../flare_dart
+    git: 
+      url: https://github.com/2d-inc/Flare-Flutter.git
+      ref: web
+      path: flare_dart


### PR DESCRIPTION
```
Error on line 11, column 11: Invalid description in the "flare_flutter" pubspec on the "flare_dart" dependency: "../flare_dart" is a relative path, but this isn't a local pubspec.
   ╷
11 │     path: ../flare_dart
   │           ^^^^^^^^^^^^^
   ╵
```