### PR TITLE
Escalate the severity of unused imports in analyzer

### DIFF
--- a/flare_dart/analysis_options.yaml
+++ b/flare_dart/analysis_options.yaml
@@ -2,6 +2,8 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+  errors:
+    unused_import: error
 
 linter:
   rules:
@@ -85,7 +87,7 @@ linter:
   - prefer_is_empty
   - prefer_is_not_empty
   - prefer_iterable_whereType
-  - prefer_mixin
+  # - prefer_mixin
   - prefer_null_aware_operators
   - prefer_typing_uninitialized_variables
   - prefer_void_to_null

--- a/flare_flutter/analysis_options.yaml
+++ b/flare_flutter/analysis_options.yaml
@@ -2,6 +2,8 @@ analyzer:
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+  errors:
+    unused_import: error
 
 linter:
   rules:
@@ -85,7 +87,7 @@ linter:
   - prefer_is_empty
   - prefer_is_not_empty
   - prefer_iterable_whereType
-  - prefer_mixin
+  # - prefer_mixin
   - prefer_null_aware_operators
   - prefer_typing_uninitialized_variables
   - prefer_void_to_null

--- a/flare_flutter/lib/flare.dart
+++ b/flare_flutter/lib/flare.dart
@@ -22,7 +22,6 @@ import 'package:flare_dart/actor_rectangle.dart';
 import 'package:flare_dart/actor_star.dart';
 import 'package:flare_dart/actor_triangle.dart';
 import 'package:flare_dart/actor_color.dart';
-import 'package:flare_dart/actor_node.dart';
 import 'package:flare_dart/actor_drawable.dart';
 import 'package:flare_dart/math/mat2d.dart';
 import 'package:flare_dart/math/vec2d.dart';


### PR DESCRIPTION
- Also remove the prefer_mixin analysis option [This is also ignored by Flutter codebase].
- Fix unused import.