### PR TITLE
Fix load and play issues between states

### DIFF
--- a/flare_flutter/lib/cache.dart
+++ b/flare_flutter/lib/cache.dart
@@ -62,4 +62,12 @@ abstract class Cache<T extends CacheAsset> {
     }
     return asset;
   }
+
+  T getAssetIfAvailable(String filename) {
+    T asset = _assets[filename];
+    if (asset != null && asset.isAvailable) {
+      return asset;
+    }
+    return null;
+  }
 }

--- a/flare_flutter/lib/flare_actor.dart
+++ b/flare_flutter/lib/flare_actor.dart
@@ -224,7 +224,8 @@ class FlareActorRenderObject extends FlareRenderBox {
   @override
   bool get isPlaying =>
       !_isPaused &&
-      ((_controller?.isActive?.value ?? false) || _animationLayers.isNotEmpty);
+      (_controller?.isActive?.value ?? true) &&
+      _animationLayers.isNotEmpty;
 
   void onControllerActiveChange() {
     updatePlayState();
@@ -260,7 +261,9 @@ class FlareActorRenderObject extends FlareRenderBox {
     }
     // file will change, let's clear out old animations.
     _animationLayers.clear();
-    load();
+    if (!loadImmediately()) {
+      load();
+    }
   }
 
   bool _instanceArtboard() {
@@ -281,13 +284,14 @@ class FlareActorRenderObject extends FlareRenderBox {
             _color.blue / 255.0,
             _color.opacity
           ]);
-    _artboard.advance(0.0);
-    updateBounds();
 
     if (_controller != null) {
       _controller.initialize(_artboard);
     }
     _updateAnimation(onlyWhenMissing: true);
+    advance(0.0);
+    updateBounds();
+
     markNeedsPaint();
     return true;
   }
@@ -302,6 +306,21 @@ class FlareActorRenderObject extends FlareRenderBox {
       return;
     }
     _instanceArtboard();
+  }
+
+  @override
+  bool loadImmediately() {
+    if (_filename == null) {
+      return false;
+    }
+
+    _actor = loadFlareFromCacheImmediately(_filename);
+    if (_actor == null || _actor.artboard == null) {
+      return false;
+    }
+
+    _instanceArtboard();
+    return true;
   }
 
   FlareCompletedCallback get completed => _completedCallback;

--- a/flare_flutter/lib/flare_cache.dart
+++ b/flare_flutter/lib/flare_cache.dart
@@ -34,3 +34,10 @@ Future<FlareCacheAsset> cachedActor(AssetBundle bundle, String filename) async {
   }
   return cache.getAsset(filename);
 }
+
+FlareCacheAsset cachedActorIfAvailable(AssetBundle bundle, String filename) {
+  FlareCache cache = _cache[bundle];
+  if (cache != null) {
+    return cache.getAssetIfAvailable(filename);
+  }
+}

--- a/flare_flutter/lib/flare_render_box.dart
+++ b/flare_flutter/lib/flare_render_box.dart
@@ -49,8 +49,10 @@ abstract class FlareRenderBox extends RenderBox {
       return;
     }
     _assetBundle = value;
-    if (_assetBundle != null) {
-      _load();
+    if (_assetBundle != null && attached) {
+      if (!loadImmediately()) {
+        _load();
+      }
     }
   }
 
@@ -112,7 +114,9 @@ abstract class FlareRenderBox extends RenderBox {
     super.attach(owner);
     updatePlayState();
     if (_assets.isEmpty && assetBundle != null) {
-      _load();
+      if (!loadImmediately()) {
+        _load();
+      }
     }
   }
 
@@ -248,6 +252,7 @@ abstract class FlareRenderBox extends RenderBox {
 
   /// Perform any loading logic necessary for this scene.
   Future<void> load() async {}
+  bool loadImmediately() { return false;}
 
   void _unload() {
     for (final FlareCacheAsset asset in _assets) {
@@ -258,6 +263,20 @@ abstract class FlareRenderBox extends RenderBox {
   }
 
   void onUnload() {}
+
+  FlutterActor loadFlareFromCacheImmediately(String filename) {
+    if (assetBundle == null || filename == null) {
+      return null;
+    }
+    FlareCacheAsset asset = cachedActorIfAvailable(assetBundle, filename);
+
+    if (!attached || asset == null) {
+      return null;
+    }
+    _assets.add(asset);
+    asset.ref();
+    return asset.actor;
+  }
 
   /// Load a flare file from cache
   Future<FlutterActor> loadFlare(String filename) async {


### PR DESCRIPTION
During the course of using flare, I've been encountered glitches every now and then such as #136 , #112 and more. Here are the fixes for some of them.
Most issues that I had were coming from state to sate in which we are particularly switching to a different flare file and a different animation or continuously using same flare animation linearly across pages. During that transition, we needed to figure out how we can handle the flareplugin loading process since it is asynchronous and a bit hard to understand.
The most painful issues to me were  rendering empty frame first between state changes or failing to resume linearly between pages.
 
1. Add a feature of loading the flare asset immediately if it can. From now on, if it can't load immediately, then it loads asynchronously as before. To fix that, I added `loadImmediately()`. It gets called before `load()` to see if it can load from the cache immediately. If it can't, then it always subsequently calls `load()` as before. 
  
2. `_isLoading` variable is not always correct. (Even `FlareActor` can call `load()` directly which wouldn't let the base class know that the call is occurring.) To fix that, `load()` won't be called if the node is not mounted. 

3. The load method was incorrectly setting things up which would cause the first frame to play the first animation frame while in `_instanceArtboard()`. The issue was that the animation layers were not loaded, and the controller was not being called to advance on the first frame. That caused the animation failed to  resume from where it left off. With this fix, now the controller keeps the flare continuing right from where it left off.

4. The flare plugin is continually drawing every single frame even though the controller said it was inactive. To fix that, I split  `((_controller?.isActive?.value ?? false) || _animationLayers.isNotEmpty);`  into two separate conditions `(_controller?.isActive?.value ?? true) &&
      _animationLayers.isNotEmpty;` Note: I set `?? true` instead of `?? false` to honor  when `_animationLayers.isNotEmpty` is true.