### PR TITLE
Added Alternative DependencySorter to deal with cycles

### DIFF
--- a/flare_dart/lib/actor_component.dart
+++ b/flare_dart/lib/actor_component.dart
@@ -31,6 +31,10 @@ abstract class ActorComponent {
     return _name;
   }
 
+  set name(String name) {
+    _name = name;
+  }
+
   void resolveComponentIndices(List<ActorComponent> components) {
     ActorNode node = components[_parentIdx] as ActorNode;
     if (node != null) {

--- a/flare_dart/lib/dependency_sorter.dart
+++ b/flare_dart/lib/dependency_sorter.dart
@@ -44,3 +44,60 @@ class DependencySorter {
     return true;
   }
 }
+
+class CycleDependencySorter extends DependencySorter {
+  HashSet<ActorComponent> _cycleNodes;
+  CycleDependencySorter() {
+    _perm = HashSet<ActorComponent>();
+    _temp = HashSet<ActorComponent>();
+    _cycleNodes = HashSet<ActorComponent>();
+  }
+
+  HashSet<ActorComponent> get cycleNodes => _cycleNodes;
+
+  @override
+  List<ActorComponent> sort(ActorComponent root) {
+    _order = <ActorComponent>[];
+    visit(root);
+    return _order;
+  }
+
+  @override
+  bool visit(ActorComponent n) {
+    // Follow the nodes along their dependencies.
+    // track visited nodes,
+    // When a cycle is detected,
+    //   scrap all visited nodes tracked until the start of the cycle
+    //   track these nodes as 'cycleNodes'
+
+    if (_perm.contains(n)) {
+      // node's dependencies have already been evaluated.
+    } else if (_temp.contains(n)) {
+      if (_cycleNodes.contains(n)) {
+        // we're onto a cycle that has already been removed.
+        return false;
+      }
+      // node is being evaluated, but not complete yet, CYCLE!
+      ActorComponent lastComponent;
+      while (lastComponent != n) {
+        lastComponent = _order.removeLast();
+        _cycleNodes.add(lastComponent);
+      }
+      return false;
+    } else {
+      _order.add(n);
+      _temp.add(n);
+      if (n.dependents != null) {
+        for (final ActorComponent dependant in n.dependents) {
+          var cycleFound = !visit(dependant);
+          if (cycleFound && _cycleNodes.contains(n)) {
+            // node is part of a cycle, we're done here.
+            return false;
+          }
+        }
+      }
+      _perm.add(n);
+    }
+    return true;
+  }
+}

--- a/flare_dart/pubspec.yaml
+++ b/flare_dart/pubspec.yaml
@@ -5,4 +5,5 @@ author: "Rive Team <info@rive.app>"
 homepage: https://github.com/2d-inc/Flare-Flutter
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  
+dev_dependencies:
+  test: ^1.9.4

--- a/flare_dart/test/test_dependency_sorter.dart
+++ b/flare_dart/test/test_dependency_sorter.dart
@@ -1,0 +1,258 @@
+import 'dart:typed_data';
+
+import 'package:flare_dart/actor_artboard.dart';
+import 'package:flare_dart/actor_color.dart';
+import 'package:flare_dart/actor_component.dart';
+import 'package:flare_dart/actor_drop_shadow.dart';
+import 'package:flare_dart/actor_inner_shadow.dart';
+import 'package:flare_dart/actor_layer_effect_renderer.dart';
+import 'package:flare_dart/actor_node.dart';
+import 'package:flare_dart/actor.dart';
+import 'package:flare_dart/dependency_sorter.dart';
+
+import 'package:test/test.dart';
+
+class DummyActor extends Actor {
+  @override
+  Future<bool> loadAtlases(List<Uint8List> rawAtlases) {
+    throw UnimplementedError();
+  }
+
+  @override
+  ColorFill makeColorFill() {
+    throw UnimplementedError();
+  }
+
+  @override
+  ColorStroke makeColorStroke() {
+    throw UnimplementedError();
+  }
+
+  @override
+  ActorDropShadow makeDropShadow() {
+    throw UnimplementedError();
+  }
+
+  @override
+  GradientFill makeGradientFill() {
+    throw UnimplementedError();
+  }
+
+  @override
+  GradientStroke makeGradientStroke() {
+    throw UnimplementedError();
+  }
+
+  @override
+  ActorInnerShadow makeInnerShadow() {
+    throw UnimplementedError();
+  }
+
+  @override
+  ActorLayerEffectRenderer makeLayerEffectRenderer() {
+    throw UnimplementedError();
+  }
+
+  @override
+  RadialGradientFill makeRadialFill() {
+    throw UnimplementedError();
+  }
+
+  @override
+  RadialGradientStroke makeRadialStroke() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Uint8List> readOutOfBandAsset(String filename, context) {
+    throw UnimplementedError();
+  }
+}
+
+String orderString(List<ActorComponent> order) {
+  String output = order.fold(
+      '',
+      (previousValue, actorComponent) =>
+          previousValue + ' ' + actorComponent.name);
+  return output.trim();
+}
+
+void main() {
+  group("Simple Cycle:", () {
+    ActorArtboard artboard;
+
+    setUp(() async {
+      final actor = DummyActor();
+      artboard = ActorArtboard(actor);
+      final nodeA = ActorNode()..name = 'A';
+      final nodeB = ActorNode()..name = 'B';
+      final nodeC = ActorNode()..name = 'C';
+      final nodeD = ActorNode()..name = 'D';
+
+      ///
+      /// [root] <- [A] <- [B] <- [D]
+      ///            A      |      A
+      ///            |      +------+
+      ///           [C]
+      artboard.addDependency(nodeA, artboard.root);
+      artboard.addDependency(nodeB, nodeA);
+      artboard.addDependency(nodeC, nodeA);
+      artboard.addDependency(nodeD, nodeB);
+      artboard.addDependency(nodeB, nodeD);
+    });
+
+    test("DependencySorter stops on cycle", () {
+      expect(DependencySorter().sort(artboard.root), equals(null));
+    });
+
+    test("CycleDependencySorter produces best guess exluding cycle nodes", () {
+      var order = CycleDependencySorter().sort(artboard.root);
+      expect(order.length, equals(3));
+      expect(orderString(order), equals('Unnamed A C'));
+    });
+  });
+  group("No cycle, but double dependants", () {
+    ActorArtboard artboard;
+
+    setUp(() async {
+      final actor = DummyActor();
+      artboard = ActorArtboard(actor);
+      final nodeA = ActorNode()..name = 'A';
+      final nodeB = ActorNode()..name = 'B';
+      final nodeC = ActorNode()..name = 'C';
+      final nodeD = ActorNode()..name = 'D';
+
+      ///
+      /// [root] <- [A] <- [B] <- [D]
+      ///            A      A
+      ///            |      |
+      ///           [C]-----+
+      artboard.addDependency(nodeA, artboard.root);
+      artboard.addDependency(nodeB, nodeA);
+      artboard.addDependency(nodeC, nodeA);
+      artboard.addDependency(nodeD, nodeB);
+      artboard.addDependency(nodeC, nodeB);
+    });
+
+    test("DependencySorter is ok", () {
+      var order = DependencySorter().sort(artboard.root);
+      expect(order, isNotNull);
+      expect(orderString(order), 'Unnamed A B C D');
+    });
+
+    test("CycleDependencySorter is ok", () {
+      var order = CycleDependencySorter().sort(artboard.root);
+      expect(order, isNotNull);
+      expect(order.length, equals(5));
+      expect(orderString(order), equals('Unnamed A B D C'));
+    });
+  });
+
+  group("Complex Cycle", () {
+    ActorArtboard artboard;
+
+    setUp(() async {
+      final actor = DummyActor();
+      artboard = ActorArtboard(actor);
+      final nodeA = ActorNode()..name = 'A';
+      final nodeB = ActorNode()..name = 'B';
+      final nodeC = ActorNode()..name = 'C';
+      final nodeD = ActorNode()..name = 'D';
+
+      ///
+      ///                   +------+
+      ///                   |      v
+      /// [root] <- [A] <- [B] <- [D]
+      ///            A             |
+      ///            |             |
+      ///           [C]<-----------+
+      ///
+      artboard.addDependency(nodeA, artboard.root);
+      artboard.addDependency(nodeB, nodeA);
+      artboard.addDependency(nodeD, nodeB);
+      artboard.addDependency(nodeB, nodeD);
+      artboard.addDependency(nodeC, nodeA);
+      artboard.addDependency(nodeD, nodeC);
+    });
+
+    test("DependencySorter is ok", () {
+      expect(DependencySorter().sort(artboard.root), equals(null));
+    });
+
+    test("CycleDependencySorter is ok", () {
+      var order = CycleDependencySorter().sort(artboard.root);
+      expect(order, isNotNull);
+      expect(order.length, equals(3));
+      expect(orderString(order), equals('Unnamed A C'));
+    });
+  });
+
+  group("Bad Cycle", () {
+    ///
+    ///                   +-------------+
+    ///                   |             |
+    ///                   |     [F]     |
+    ///                   |      v      v
+    /// [root] <- [A] <- [B] <- [C] <- [D]
+    ///            A             |
+    ///            |             |
+    ///           [E]<-----------+
+    ///
+
+    test("CycleDependencySorter expected [root A E]", () {
+      final actor = DummyActor();
+      final artboard = ActorArtboard(actor);
+      final nodeA = ActorNode()..name = 'A';
+      final nodeB = ActorNode()..name = 'B';
+      final nodeC = ActorNode()..name = 'C';
+      final nodeD = ActorNode()..name = 'D';
+      final nodeE = ActorNode()..name = 'E';
+      final nodeF = ActorNode()..name = 'F';
+
+      artboard.addDependency(nodeA, artboard.root);
+      artboard.addDependency(nodeB, nodeA);
+      artboard.addDependency(nodeC, nodeB);
+      artboard.addDependency(nodeD, nodeC);
+      artboard.addDependency(nodeB, nodeD);
+      artboard.addDependency(nodeE, nodeA);
+      artboard.addDependency(nodeC, nodeE);
+      artboard.addDependency(nodeF, nodeC);
+      var dependencySorter = CycleDependencySorter();
+      var order = dependencySorter.sort(artboard.root);
+      expect(order, isNotNull);
+      expect(order.length, equals(3));
+      expect(orderString(order), equals('Unnamed A E'));
+      expect(dependencySorter.cycleNodes,
+          containsAll([nodeB, nodeC, nodeD, nodeF]),
+          skip: "CycleNodes will not include F, as it was"
+              " found to be dependant on a cycle before being evaluated.");
+    });
+
+    test("CycleDependencySorter reorderd expected [root A E]", () {
+      final actor = DummyActor();
+      final artboard = ActorArtboard(actor);
+      final nodeA = ActorNode()..name = 'A';
+      final nodeB = ActorNode()..name = 'B';
+      final nodeC = ActorNode()..name = 'C';
+      final nodeD = ActorNode()..name = 'D';
+      final nodeE = ActorNode()..name = 'E';
+      final nodeF = ActorNode()..name = 'F';
+
+      artboard.addDependency(nodeA, artboard.root);
+      artboard.addDependency(nodeE, nodeA);
+      artboard.addDependency(nodeC, nodeE);
+      artboard.addDependency(nodeF, nodeC);
+      artboard.addDependency(nodeB, nodeA);
+      artboard.addDependency(nodeC, nodeB);
+      artboard.addDependency(nodeD, nodeC);
+      artboard.addDependency(nodeB, nodeD);
+      var dependencySorter = CycleDependencySorter();
+      var order = dependencySorter.sort(artboard.root);
+      expect(order, isNotNull);
+      expect(order.length, equals(3));
+      expect(orderString(order), equals('Unnamed A E'));
+      expect(dependencySorter.cycleNodes,
+          containsAll([nodeB, nodeC, nodeD, nodeF]));
+    });
+  });
+}


### PR DESCRIPTION
Couple of outstanding questions:
- would we want to activate this straight away, right now I've not committed using this (and essentially replacing the previous Sorter)
- this will make sure we have an ordered list of ActorComponents, but its of course not alerting anything that we are missing  components if there were cycles. Something else will need to be responsible for that
- the alternative sounds kinda better

**tests**:
Manually tested drawing the penguin using this dependency sorter. 
Added some tests to keep track of some scenarios I've been trying to make sure work. not sure if we want to fit tests in like this

To run the tests `pub run test test/test_dependency_sorter.dart` does the trick.

**Some gotchas**:
the order that the nodes are evaluated is not the same as in the original Dependency Sorter

**Alternatives**:
this looks pretty promising really. looks like a an established algorithm to find all cycles: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm. 
Using this we could simply use the current algorithm, and if it detects cycles, find all nodes with cycles and then re run the current algorithm, skipping over any nodes that are part of a cycle. We'll of course lose a little bit 