### PR TITLE
Advance on needs paint

### DIFF
--- a/example/teddy/lib/teddy_controller.dart
+++ b/example/teddy/lib/teddy_controller.dart
@@ -113,7 +113,7 @@ class TeddyController extends FlareControls {
   }
 
   bool _isCoveringEyes = false;
-  coverEyes(cover) {
+  void coverEyes(bool cover) {
     if (_isCoveringEyes == cover) {
       return;
     }

--- a/flare_dart/lib/actor_artboard.dart
+++ b/flare_dart/lib/actor_artboard.dart
@@ -307,7 +307,7 @@ class ActorArtboard {
     }
   }
 
-  void advance(double seconds) {
+  void advance() {
     if ((_flags & ActorFlags.isDirty) != 0) {
       const int maxSteps = 100;
       int step = 0;

--- a/flare_flutter/lib/flare_actor.dart
+++ b/flare_flutter/lib/flare_actor.dart
@@ -476,7 +476,7 @@ class FlareActorRenderObject extends FlareRenderBox {
     }
 
     if (_artboard != null) {
-      _artboard.advance(elapsedSeconds);
+      _artboard.advance();
     }
   }
 
@@ -517,9 +517,15 @@ class FlareActorRenderObject extends FlareRenderBox {
           ..mix = 1.0
           ..mixSeconds = 0.2);
         animation.apply(0.0, _artboard, 1.0);
-        _artboard.advance(0.0);
+        _artboard.advance();
         updatePlayState();
       }
     }
+  }
+
+  @override
+  void markNeedsPaint() {
+    if (!isPlaying) _artboard?.advance();
+    super.markNeedsPaint();
   }
 }

--- a/flare_flutter/lib/flare_cache_builder.dart
+++ b/flare_flutter/lib/flare_cache_builder.dart
@@ -5,12 +5,20 @@ import 'asset_provider.dart';
 import 'flare_cache.dart';
 import 'flare_cache_asset.dart';
 
-/// Create a mobile or tablet layout depending on the screen size.
+/// [FlareCacheBuilder] is a Stateful widget that builds another widget.
+///
+/// The list of [AssetProvider] will be loaded asynchronously and placed
+/// in [FlareCache].
+///
+/// The [builder] function will build the widget to be displayed on the screen
+/// and uses [_isWarm] to let the caller know if the assets are fully loaded
+/// or not.
 class FlareCacheBuilder extends StatefulWidget {
   final Widget Function(BuildContext, bool) builder;
   final List<AssetProvider> assetProviders;
 
-  const FlareCacheBuilder(this.assetProviders, {Key key, this.builder})
+  const FlareCacheBuilder(this.assetProviders,
+      {@required this.builder, Key key})
       : super(key: key);
 
   @override


### PR DESCRIPTION
Overrides `markNeedsPaint()` to force advancing an artboard if it's not playing (#256)

Also, removes unused parameter from `artboard.advance()`

Some other minor fixes & documentation.