### PR TITLE
Remove unused dart:async import

### DIFF
--- a/flare_flutter/lib/flare_cache.dart
+++ b/flare_flutter/lib/flare_cache.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'asset_provider.dart';
 import 'cache.dart';
 import 'flare_cache_asset.dart';


### PR DESCRIPTION
As of Dart 2.1, Future and Stream have been exported from dart:core