### PR TITLE
Hotfix/ik constraint

### DIFF
--- a/flare_flutter/android/.gitignore
+++ b/flare_flutter/android/.gitignore
@@ -1,0 +1,1 @@
+local.properties

--- a/flare_flutter/android/local.properties
+++ b/flare_flutter/android/local.properties
@@ -1,2 +1,0 @@
-sdk.dir=/home/st/Android/Sdk
-flutter.sdk=/home/st/Documents/dev-ops/flutter/flutter

--- a/flare_flutter/android/local.properties
+++ b/flare_flutter/android/local.properties
@@ -1,2 +1,2 @@
-sdk.dir=/Users/luigi/Library/Android/sdk
-flutter.sdk=/Users/luigi/Projects/flutter/flutter
+sdk.dir=/home/st/Android/Sdk
+flutter.sdk=/home/st/Documents/dev-ops/flutter/flutter

--- a/flare_flutter/ios/Runner/GeneratedPluginRegistrant.h
+++ b/flare_flutter/ios/Runner/GeneratedPluginRegistrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GeneratedPluginRegistrant_h
 #define GeneratedPluginRegistrant_h
 

--- a/flare_flutter/ios/Runner/GeneratedPluginRegistrant.m
+++ b/flare_flutter/ios/Runner/GeneratedPluginRegistrant.m
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #import "GeneratedPluginRegistrant.h"
 
 @implementation GeneratedPluginRegistrant

--- a/flare_flutter/lib/base/actor_ik_constraint.dart
+++ b/flare_flutter/lib/base/actor_ik_constraint.dart
@@ -253,14 +253,14 @@ class ActorIKConstraint extends ActorTargetedConstraint {
   void solve2(BoneChain fk1, BoneChain fk2, Vec2D worldTargetTranslation) {
     ActorBone b1 = fk1.bone;
     ActorBone b2 = fk2.bone;
-    BoneChain? firstChild = _fkChain.firstWhereOrNull(
+    BoneChain firstChild = (_fkChain.firstWhereOrNull(
       (chain) => chain.index == fk1.index + 1
-    );
+    ))!;
 
     Mat2D iworld = fk1.parentWorldInverse;
 
     Vec2D pA = b1.getWorldTranslation(Vec2D());
-    Vec2D pC = firstChild!.bone.getWorldTranslation(Vec2D());
+    Vec2D pC = firstChild.bone.getWorldTranslation(Vec2D());
     Vec2D pB = b2.getTipWorldTranslation(Vec2D());
 
     Vec2D pBT = Vec2D.clone(worldTargetTranslation);

--- a/flare_flutter/lib/base/actor_ik_constraint.dart
+++ b/flare_flutter/lib/base/actor_ik_constraint.dart
@@ -64,7 +64,8 @@ class ActorIKConstraint extends ActorTargetedConstraint {
       for (int i = 0; i < _boneData.length - 1; i++) {
         BoneChain item = _boneData[i];
         item.included = true;
-        _fkChain[item.index + 1].included = true;
+        _fkChain.firstWhereOrNull((element) => element.index == item.index + 1)
+          ?.included = true;
       }
     }
 
@@ -252,12 +253,14 @@ class ActorIKConstraint extends ActorTargetedConstraint {
   void solve2(BoneChain fk1, BoneChain fk2, Vec2D worldTargetTranslation) {
     ActorBone b1 = fk1.bone;
     ActorBone b2 = fk2.bone;
-    BoneChain firstChild = _fkChain[fk1.index + 1];
+    BoneChain? firstChild = _fkChain.firstWhereOrNull(
+      (chain) => chain.index == fk1.index + 1
+    );
 
     Mat2D iworld = fk1.parentWorldInverse;
 
     Vec2D pA = b1.getWorldTranslation(Vec2D());
-    Vec2D pC = firstChild.bone.getWorldTranslation(Vec2D());
+    Vec2D pC = firstChild!.bone.getWorldTranslation(Vec2D());
     Vec2D pB = b2.getTipWorldTranslation(Vec2D());
 
     Vec2D pBT = Vec2D.clone(worldTargetTranslation);

--- a/flare_flutter/lib/base/actor_ik_constraint.dart
+++ b/flare_flutter/lib/base/actor_ik_constraint.dart
@@ -203,7 +203,7 @@ class ActorIKConstraint extends ActorTargetedConstraint {
     _invertDirection = node._invertDirection;
     if (node._influencedBones != null) {
       _influencedBones = <InfluencedBone>[];
-      for (int i = 0; i < _influencedBones!.length; i++) {
+      for (int i = 0; i < node._influencedBones!.length; i++) {
         _influencedBones!
             .add(InfluencedBone(node._influencedBones![i].boneIdx));
       }


### PR DESCRIPTION
`copyIKConstraint()` is supposed to copy `_influencedBones` from target constraint `node`. Instead it mistakenly copies the instance's `_influencedBones` to itself which will always be empty at that point, leaving bones unconstrained.