### PR TITLE
Make compatible with new RenderObject.dispose API

### DIFF
--- a/flare_flutter/lib/flare_actor.dart
+++ b/flare_flutter/lib/flare_actor.dart
@@ -170,11 +170,6 @@ class FlareActor extends LeafRenderObjectWidget {
   }
 
   @override
-  void didUnmountRenderObject(covariant FlareActorRenderObject renderObject) {
-    renderObject.dispose();
-  }
-
-  @override
   void updateRenderObject(
       BuildContext context, covariant FlareActorRenderObject renderObject) {
     renderObject

--- a/flare_flutter/lib/flare_render_box.dart
+++ b/flare_flutter/lib/flare_render_box.dart
@@ -96,14 +96,10 @@ abstract class FlareRenderBox extends RenderBox {
   Future<void> coldLoad() async {}
 
   @override
-  void detach() {
-    super.detach();
-    dispose();
-  }
-
   void dispose() {
     updatePlayState();
     _unload();
+    super.dispose();
   }
 
   /// Load a flare file from cache


### PR DESCRIPTION
After https://github.com/flutter/flutter/commit/c1fe2bd1e0fef2d9f54d51c59f58cb32c33a0726, `RenderObject.dispose` expects overrides to call super.

The framework now calls this method automatically at the right times, so the manual calls can be removed.