### PR TITLE
fix #313  #312 onBlendModeChanged _paint LateInitializationError

### DIFF
--- a/flare_flutter/lib/flare.dart
+++ b/flare_flutter/lib/flare.dart
@@ -310,7 +310,7 @@ class FlutterActorEllipse extends ActorEllipse with FlutterPathPointsPath {
 class FlutterActorImage extends ActorImage with FlutterActorDrawable {
   late Float32List _vertexBuffer;
   late Float32List _uvBuffer;
-  late ui.Paint _paint;
+  ui.Paint? _paint;
   ui.Vertices? _canvasVertices;
   late Uint16List _indices;
 
@@ -339,7 +339,7 @@ class FlutterActorImage extends ActorImage with FlutterActorDrawable {
         ..blendMode = blendMode
         ..shader = textureIndex >= 0 && textureIndex < images.length
             ? ui.ImageShader(images[textureIndex], ui.TileMode.clamp,
-                ui.TileMode.clamp, _identityMatrix)
+            ui.TileMode.clamp, _identityMatrix)
             : null
         ..filterQuality = ui.FilterQuality.low
         ..isAntiAlias = antialias;
@@ -366,7 +366,7 @@ class FlutterActorImage extends ActorImage with FlutterActorDrawable {
       idx += 2;
     }
 
-    _paint.shader = ui.ImageShader(
+    _paint?.shader = ui.ImageShader(
         image, ui.TileMode.clamp, ui.TileMode.clamp, _identityMatrix);
 
     _canvasVertices = ui.Vertices.raw(ui.VertexMode.triangles, _vertexBuffer,
@@ -435,14 +435,14 @@ class FlutterActorImage extends ActorImage with FlutterActorDrawable {
     canvas.save();
 
     clip(canvas);
-    _paint.color =
-        _paint.color.withOpacity(renderOpacity.clamp(0.0, 1.0).toDouble());
+    _paint?.color =
+        _paint!.color.withOpacity(renderOpacity.clamp(0.0, 1.0).toDouble());
 
     if (imageTransform != null) {
       canvas.transform(imageTransform!.mat4);
-      canvas.drawVertices(_canvasVertices!, ui.BlendMode.srcOver, _paint);
+      canvas.drawVertices(_canvasVertices!, ui.BlendMode.srcOver, _paint!);
     } else {
-      canvas.drawVertices(_canvasVertices!, ui.BlendMode.srcOver, _paint);
+      canvas.drawVertices(_canvasVertices!, ui.BlendMode.srcOver, _paint!);
     }
 
     canvas.restore();
@@ -496,17 +496,17 @@ class FlutterActorImage extends ActorImage with FlutterActorDrawable {
 
   @override
   void onAntialiasChanged(bool useAA) {
-    _paint.isAntiAlias = useAA;
+    _paint?.isAntiAlias = useAA;
     onPaintUpdated(_paint);
   }
 
   @override
   void onBlendModeChanged(ui.BlendMode mode) {
-    _paint.blendMode = mode;
+    _paint?.blendMode = mode;
     onPaintUpdated(_paint);
   }
 
-  void onPaintUpdated(ui.Paint paint) {}
+  void onPaintUpdated(ui.Paint? paint) {}
 
   @override
   void update(int dirt) {

--- a/flare_flutter/lib/flare_render_box.dart
+++ b/flare_flutter/lib/flare_render_box.dart
@@ -164,10 +164,10 @@ abstract class FlareRenderBox extends RenderBox {
     if (isPlaying) {
       // Paint again
       if (_frameCallbackID != -1) {
-        SchedulerBinding.instance?.cancelFrameCallbackWithId(_frameCallbackID);
+        SchedulerBinding.instance.cancelFrameCallbackWithId(_frameCallbackID);
       }
       _frameCallbackID =
-          SchedulerBinding.instance?.scheduleFrameCallback(_beginFrame) ?? -1;
+          SchedulerBinding.instance.scheduleFrameCallback(_beginFrame) ?? -1;
     }
 
     final Canvas canvas = context.canvas;
@@ -269,7 +269,7 @@ abstract class FlareRenderBox extends RenderBox {
     } else {
       _lastFrameTime = _notPlayingFlag;
       if (_frameCallbackID != -1) {
-        SchedulerBinding.instance?.cancelFrameCallbackWithId(_frameCallbackID);
+        SchedulerBinding.instance.cancelFrameCallbackWithId(_frameCallbackID);
       }
     }
   }

--- a/flare_flutter/lib/flare_render_box.dart
+++ b/flare_flutter/lib/flare_render_box.dart
@@ -167,7 +167,7 @@ abstract class FlareRenderBox extends RenderBox {
         SchedulerBinding.instance.cancelFrameCallbackWithId(_frameCallbackID);
       }
       _frameCallbackID =
-          SchedulerBinding.instance.scheduleFrameCallback(_beginFrame) ?? -1;
+          SchedulerBinding.instance.scheduleFrameCallback(_beginFrame);
     }
 
     final Canvas canvas = context.canvas;


### PR DESCRIPTION
```
[VERBOSE-2:ui_dart_state.cc(209)] Unhandled Exception: Exception: LateInitializationError: Field '_paint@268459774' has not been initialized.
#0      FlutterActorImage._paint (package:flare_flutter/flare.dart)
#1      FlutterActorImage.onBlendModeChanged (package:flare_flutter/flare.dart:505:5)
#2      FlutterActorDrawable.blendMode= (package:flare_flutter/flare.dart:226:5)
#3      FlutterActorDrawable.blendModeId= (package:flare_flutter/flare.dart:234:5)
#4      ActorDrawable.read (package:flare_flutter/base/actor_drawable.dart:77:17)
#5      ActorImage.read (package:flare_flutter/base/actor_image.dart:305:19)
#6      ActorArtboard.readComponentsBlock (package:flare_flutter/base/actor_artboard.dart:387:34)
#7      ActorArtboard.read (package:flare_flutter/base/actor_artboard.dart:349:11)
```

#### In  `onBlendModeChanged` Function, `_paint`  never initialized  when  `ActorDrawable read -> set blendModeId` ，but  `_paint` sound `late ui.Paint`

```
  @override
  void onBlendModeChanged(ui.BlendMode mode) {
     _paint.blendMode = mode;
    onPaintUpdated(_paint);
  }
```

<img width="592" alt="image" src="https://user-images.githubusercontent.com/10770362/134443606-7079bdaf-01a7-4924-9574-36e7cf396e84.png">


