### PR TITLE
Remove `hashValues`

### DIFF
--- a/flare_flutter/lib/provider/asset_flare.dart
+++ b/flare_flutter/lib/provider/asset_flare.dart
@@ -1,5 +1,4 @@
 import 'package:flare_flutter/asset_provider.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
@@ -22,10 +21,10 @@ class AssetFlare extends AssetProvider {
   });
 
   @override
-  int get hashCode => hashValues(bundle, name);
+  int get hashCode => Object.hash(bundle, name);
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) {
       return false;
     }

--- a/flare_flutter/pubspec.yaml
+++ b/flare_flutter/pubspec.yaml
@@ -4,14 +4,14 @@ version: 3.0.2
 homepage: https://github.com/2d-inc/Flare-Flutter
 
 dependencies:
-  collection: ^1.15.0
+  collection: ^1.19.0
   flutter:
     sdk: flutter
-  meta: ^1.3.0
+  meta: ^1.15.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
**Summary**
This PR removes the usage of deprecated hashValues in favor of Object.hash to align with the latest changes in Flutter 3.27.0.

Deprecated hashValues function has been replaced by Object.hash in all relevant files.
Reference: https://github.com/flutter/flutter/pull/151677

Upgrade dependencies

**Changes**
Replaced hashValues with Object.hash

Closes: #325