### PR TITLE
fix deprecated hashValues function

### DIFF
--- a/flare_flutter/lib/provider/asset_flare.dart
+++ b/flare_flutter/lib/provider/asset_flare.dart
@@ -22,7 +22,7 @@ class AssetFlare extends AssetProvider {
   });
 
   @override
-  int get hashCode => hashValues(bundle, name);
+  int get hashCode => Object.hash(bundle, name);
 
   @override
   bool operator ==(dynamic other) {


### PR DESCRIPTION
In Flutter, hashValues used to be part of the flutter package, but it has been deprecated and replaced with Object.hash. This has packages depending on the Flare-Flutter to cause build issues. For example, users of Cool Alert package cannot build their apps after upgrading flutter to 3.27.2